### PR TITLE
feat: add document rendering CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ orphan-detection commands.
 - [CLI Reference](#cli-reference)
   - [Default: list requirements (legacy)](#default-list-requirements-legacy)
   - [list / entities](#list--entities)
+  - [doc \<doc-id\>](#doc-doc-id)
   - [trace \<id\>](#trace-id)
   - [coverage](#coverage)
   - [orphan](#orphan)
@@ -53,6 +54,9 @@ cd src && make
 
 # Find requirements and test cases with no links at all
 ./vibe-req orphan
+
+# Render one SRS/SDD document together with its member entities
+./vibe-req doc SRS-CLIENT-001 --output srs.md
 
 # Get help
 ./vibe-req --help
@@ -144,6 +148,30 @@ vibe-req list requirements/
 +---------------+------------------------------------+-------------+----------+----------+
 
 Total: 4 entities
+```
+
+### doc \<doc-id\>
+
+`doc` renders a single document entity together with every entity that is
+part of it. Membership is resolved through the same relation graph used for
+traceability, so both `documents:` YAML membership and explicit `part-of` /
+`contains` links are included.
+
+```bash
+vibe-req doc <doc-id> [--format md|html] [--output <file>] [directory]
+```
+
+**Examples:**
+
+```bash
+# Print a document to stdout as Markdown
+vibe-req doc SRS-CLIENT-001
+
+# Write an HTML version of the SDD to a file
+vibe-req doc SDD-SYSTEM-001 --format html --output sdd.html
+
+# Scan a specific directory
+vibe-req doc SRS-CLIENT-001 requirements/
 ```
 
 ### trace \<id\>

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -328,6 +328,46 @@ The system shall support email and password authentication for all users.
 
 ---
 
+### doc
+
+Render a single document entity together with the entities that are part of
+it. The command reuses the same Markdown / HTML report rendering as `report`,
+but narrows the input to one SRS/SDD document plus its members.
+
+```bash
+vibe-req doc <doc-id> [--format md|html] [--output <file>] [directory]
+```
+
+#### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<doc-id>` | The document entity ID to render (required) |
+| `directory` | Root directory to scan (default: `.`) |
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--format md` | Output Markdown (default) |
+| `--format html` | Output a self-contained HTML document with inline CSS |
+| `--output <file>` | Write the rendered document to `<file>` instead of stdout |
+
+#### Examples
+
+```bash
+# Markdown document to stdout
+vibe-req doc SRS-CLIENT-001
+
+# HTML document to a file
+vibe-req doc SDD-SYSTEM-001 --format html --output sdd.html
+
+# Render a document from a specific directory
+vibe-req doc SRS-CLIENT-001 requirements/
+```
+
+---
+
 ### new
 
 Scaffold a new entity YAML file.  Creates `<id>.yaml` in the given

--- a/src/cli_args.c
+++ b/src/cli_args.c
@@ -36,6 +36,9 @@ void cli_print_help(const char *prog)
     printf("  report          Generate a Markdown report of all entities.\n");
     printf("                  Use --output and filter flags to customise output.\n");
     printf("                  Example: %s report --output report.md\n\n", prog);
+    printf("  doc <id>        Print a document entity (SRS/SDD) together with all\n");
+    printf("                  entities that are part of it.\n");
+    printf("                  Example: %s doc SRS-CLIENT-001 --output srs.md\n\n", prog);
     printf("  new <type> <id> Scaffold a new entity YAML file named <id>.yaml.\n");
     printf("                  Types: requirement, group, story, design-note,\n");
     printf("                         section, assumption, constraint, test-case,\n");
@@ -54,7 +57,7 @@ void cli_print_help(const char *prog)
     printf("                                  attachment\n");
     printf("  --status <status>    Show only entities with the given lifecycle status.\n");
     printf("  --priority <prio>    Show only entities with the given priority.\n\n");
-    printf("Report options (for 'report'):\n");
+    printf("Report options (for 'report' / 'doc'):\n");
     printf("  --format md     Output Markdown (default).\n");
     printf("  --format html   Output a self-contained HTML document.\n");
     printf("  --output <file> Write report to <file> instead of stdout.\n\n");
@@ -119,6 +122,15 @@ void cli_parse_args(int argc, char *argv[], CliOptions *opts)
     } else if (strcmp(argv[1], "report") == 0) {
         opts->show_report = 1;
         arg_idx = 2;
+    } else if (strcmp(argv[1], "doc") == 0) {
+        if (argc < 3) {
+            opts->parse_error = 1;
+            opts->error_msg   = "error: 'doc' requires a document ID argument";
+            return;
+        }
+        opts->is_doc_cmd = 1;
+        opts->doc_id     = argv[2];
+        arg_idx = 3;
     } else if (strcmp(argv[1], "new") == 0) {
         if (argc < 4) {
             opts->parse_error = 1;

--- a/src/cli_args.h
+++ b/src/cli_args.h
@@ -28,7 +28,8 @@ extern "C" {
  *   1. Check parse_error — if non-zero, print error_msg and exit(1).
  *   2. Check show_help  — if set, call cli_print_help() and return 0.
  *   3. Check is_new_cmd — if set, handle the 'new' subcommand.
- *   4. Otherwise dispatch the appropriate command using the flag fields.
+ *   4. Check is_doc_cmd — if set, handle the 'doc' subcommand.
+ *   5. Otherwise dispatch the appropriate command using the flag fields.
  */
 typedef struct {
     /* ------------------------------------------------------------------ */
@@ -54,6 +55,16 @@ typedef struct {
     int         show_report;
 
     /**
+     * Non-zero when the 'doc' subcommand was detected.
+     * The caller is responsible for resolving the target document and
+     * rendering it with report_write().
+     */
+    int         is_doc_cmd;
+
+    /** Document ID argument for 'doc'; valid when is_doc_cmd is set. */
+    const char *doc_id;
+
+    /**
      * Entity ID argument for the 'trace' subcommand.
      * NULL when the trace subcommand was not requested.
      */
@@ -76,7 +87,7 @@ typedef struct {
     const char *filter_priority;
 
     /* ------------------------------------------------------------------ */
-    /* Report options (for 'report')                                      */
+    /* Report options (for 'report' / 'doc')                              */
     /* ------------------------------------------------------------------ */
 
     /** Output file path from --output <file>; NULL means stdout. */

--- a/src/list_cmd.c
+++ b/src/list_cmd.c
@@ -287,6 +287,71 @@ TripletStore *build_entity_relation_store(const EntityList *list)
     return store;
 }
 
+static const Entity *find_entity_by_id(const EntityList *list, const char *id)
+{
+    for (int i = 0; i < list->count; i++) {
+        if (strcmp(list->items[i].identity.id, id) == 0)
+            return &list->items[i];
+    }
+    return NULL;
+}
+
+static int list_contains_entity_id(const EntityList *list, const char *id)
+{
+    return find_entity_by_id(list, id) != NULL;
+}
+
+static int entity_is_member_of_document(const TripletStore *store,
+                                        const char *entity_id,
+                                        const char *doc_id)
+{
+    CTripleList by_subject = triplet_store_find_by_subject(store, entity_id);
+    int is_member = 0;
+
+    for (size_t i = 0; i < by_subject.count; i++) {
+        const CTriple *triple = &by_subject.triples[i];
+        if (strcmp(triple->predicate, "part-of") == 0 &&
+            strcmp(triple->object, doc_id) == 0) {
+            is_member = 1;
+            break;
+        }
+    }
+
+    triplet_store_list_free(by_subject);
+    return is_member;
+}
+
+int collect_document_entities(const EntityList *all, const TripletStore *store,
+                              const char *doc_id, EntityList *out)
+{
+    const Entity *doc = find_entity_by_id(all, doc_id);
+    if (!doc)
+        return -1;
+    if (doc->identity.kind != ENTITY_KIND_DOCUMENT)
+        return -2;
+
+    if (entity_list_add(out, doc) != 0)
+        return -3;
+
+    for (int i = 0; i < all->count; i++) {
+        const Entity *entity = &all->items[i];
+
+        if (strcmp(entity->identity.id, doc_id) == 0)
+            continue;
+
+        if (!entity_is_member_of_document(store, entity->identity.id, doc_id))
+            continue;
+
+        if (list_contains_entity_id(out, entity->identity.id))
+            continue;
+
+        if (entity_list_add(out, entity) != 0)
+            return -3;
+    }
+
+    return 0;
+}
+
 /* ------------------------------------------------------------------ */
 /* Table rendering — entities (ECS)                                   */
 /* ------------------------------------------------------------------ */

--- a/src/list_cmd.h
+++ b/src/list_cmd.h
@@ -79,6 +79,26 @@ void cmd_trace_entity(const EntityList *elist, const TripletStore *store,
  */
 int check_strict_links(const TripletStore *store);
 
+/**
+ * Collect a document entity and all entities that are members of it.
+ *
+ * The output always includes the document entity itself followed by every
+ * entity whose relation graph contains a `part-of -> <doc_id>` edge. This
+ * covers both `documents:` YAML membership and explicit `part-of` /
+ * `contains` traceability relations.
+ *
+ * @param all     source entity list containing the full discovered dataset
+ * @param store   TripletStore populated from @p all and with inverses inferred
+ * @param doc_id  document entity identifier to collect
+ * @param out     destination list initialised by the caller
+ * @return        0 on success
+ *               -1 if no entity with @p doc_id exists
+ *               -2 if the matching entity is not a document
+ *               -3 on allocation failure while building @p out
+ */
+int collect_document_entities(const EntityList *all, const TripletStore *store,
+                              const char *doc_id, EntityList *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,11 @@ int main(int argc, char *argv[])
         fprintf(stderr, "%s\n", opts.error_msg);
         if (opts.is_new_cmd)
             fprintf(stderr, "usage: %s new <type> <id> [directory]\n", argv[0]);
+        if (opts.is_doc_cmd)
+            fprintf(stderr,
+                    "usage: %s doc <doc-id> [--format md|html] "
+                    "[--output <file>] [directory]\n",
+                    argv[0]);
         return 1;
     }
 
@@ -149,6 +154,71 @@ int main(int argc, char *argv[])
 
         entity_list_free(&filtered);
         triplet_store_destroy(store);
+        entity_list_free(&elist);
+        return 0;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* 'doc' subcommand                                                    */
+    /* ------------------------------------------------------------------ */
+    if (opts.is_doc_cmd) {
+        TripletStore *store = build_entity_relation_store(&elist);
+        if (!store) {
+            fprintf(stderr, "error: failed to create relation store\n");
+            entity_list_free(&elist);
+            return 1;
+        }
+
+        EntityList doc_entities;
+        entity_list_init(&doc_entities);
+
+        int rc = collect_document_entities(&elist, store, opts.doc_id,
+                                           &doc_entities);
+        if (rc == -1) {
+            fprintf(stderr, "error: document '%s' not found\n", opts.doc_id);
+            triplet_store_destroy(store);
+            entity_list_free(&doc_entities);
+            entity_list_free(&elist);
+            return 1;
+        }
+        if (rc == -2) {
+            fprintf(stderr, "error: entity '%s' is not a document\n",
+                    opts.doc_id);
+            triplet_store_destroy(store);
+            entity_list_free(&doc_entities);
+            entity_list_free(&elist);
+            return 1;
+        }
+        if (rc != 0) {
+            fprintf(stderr,
+                    "error: failed to collect document members for '%s'\n",
+                    opts.doc_id);
+            triplet_store_destroy(store);
+            entity_list_free(&doc_entities);
+            entity_list_free(&elist);
+            return 1;
+        }
+
+        FILE *out = stdout;
+        if (opts.report_output) {
+            out = fopen(opts.report_output, "w");
+            if (!out) {
+                fprintf(stderr, "error: cannot open output file '%s'\n",
+                        opts.report_output);
+                triplet_store_destroy(store);
+                entity_list_free(&doc_entities);
+                entity_list_free(&elist);
+                return 1;
+            }
+        }
+
+        report_write(out, &doc_entities, store, opts.report_format);
+
+        if (opts.report_output)
+            fclose(out);
+
+        triplet_store_destroy(store);
+        entity_list_free(&doc_entities);
         entity_list_free(&elist);
         return 0;
     }

--- a/src/tests/test_cli_args.cpp
+++ b/src/tests/test_cli_args.cpp
@@ -6,7 +6,7 @@
  *   - Default values when no arguments are given
  *   - Help flag detection (-h and --help)
  *   - Each subcommand (links, list, entities, trace, coverage, orphan,
- *     report, new)
+ *     report, doc, new)
  *   - All filter flags (--kind, --component, --status, --priority)
  *   - Report flags (--output, --format md, --format html)
  *   - --strict-links flag
@@ -68,7 +68,9 @@ TEST(CliParseArgsTest, NoArgumentsGivesDefaults)
     EXPECT_EQ(opts.show_coverage, 0);
     EXPECT_EQ(opts.show_orphan,   0);
     EXPECT_EQ(opts.show_report,   0);
+    EXPECT_EQ(opts.is_doc_cmd,    0);
     EXPECT_EQ(opts.is_new_cmd,    0);
+    EXPECT_EQ(opts.doc_id,        nullptr);
     EXPECT_EQ(opts.trace_id,      nullptr);
     EXPECT_STREQ(opts.root,       ".");
     EXPECT_EQ(opts.filter_kind,     nullptr);
@@ -175,6 +177,25 @@ TEST(CliParseArgsTest, ReportSubcommand)
     cli_parse_args(a.argc(), a.argv(), &opts);
     EXPECT_EQ(opts.show_report, 1);
     EXPECT_EQ(opts.parse_error, 0);
+}
+
+TEST(CliParseArgsTest, DocSubcommandSetsDocumentId)
+{
+    Argv a{"vibe-req", "doc", "SRS-001"};
+    CliOptions opts;
+    cli_parse_args(a.argc(), a.argv(), &opts);
+    EXPECT_EQ(opts.parse_error, 0);
+    EXPECT_EQ(opts.is_doc_cmd, 1);
+    EXPECT_STREQ(opts.doc_id, "SRS-001");
+}
+
+TEST(CliParseArgsTest, DocMissingIdGivesParseError)
+{
+    Argv a{"vibe-req", "doc"};
+    CliOptions opts;
+    cli_parse_args(a.argc(), a.argv(), &opts);
+    EXPECT_NE(opts.parse_error, 0);
+    EXPECT_NE(opts.error_msg, nullptr);
 }
 
 /* =========================================================================
@@ -432,6 +453,20 @@ TEST(CliParseArgsTest, ReportWithFiltersAndDirectory)
     EXPECT_STREQ(opts.root, "requirements/");
 }
 
+TEST(CliParseArgsTest, DocWithFormatOutputAndDirectory)
+{
+    Argv a{"vibe-req", "doc", "SRS-001", "--format", "html",
+           "--output", "srs.html", "requirements/"};
+    CliOptions opts;
+    cli_parse_args(a.argc(), a.argv(), &opts);
+    EXPECT_EQ(opts.parse_error, 0);
+    EXPECT_EQ(opts.is_doc_cmd, 1);
+    EXPECT_STREQ(opts.doc_id, "SRS-001");
+    EXPECT_EQ(opts.report_format, REPORT_FORMAT_HTML);
+    EXPECT_STREQ(opts.report_output, "srs.html");
+    EXPECT_STREQ(opts.root, "requirements/");
+}
+
 /* =========================================================================
  * Tests — --strict-links and directory argument
  * ======================================================================= */
@@ -508,6 +543,7 @@ TEST(CliPrintHelpTest, PrintsUsageLine)
     EXPECT_THAT(out, HasSubstr("Usage:"));
     EXPECT_THAT(out, HasSubstr("vibe-req"));
     EXPECT_THAT(out, HasSubstr("list"));
+    EXPECT_THAT(out, HasSubstr("doc <id>"));
     EXPECT_THAT(out, HasSubstr("coverage"));
     EXPECT_THAT(out, HasSubstr("orphan"));
     EXPECT_THAT(out, HasSubstr("--kind"));

--- a/src/tests/test_main.cpp
+++ b/src/tests/test_main.cpp
@@ -275,6 +275,94 @@ TEST(BuildEntityRelationStoreTest, DocMembershipBecomesPartOfTriple)
 }
 
 /* =========================================================================
+ * Tests — collect_document_entities
+ * ======================================================================= */
+
+TEST(CollectDocumentEntitiesTest, MissingDocumentReturnsMinusOne)
+{
+    EntityList list;
+    entity_list_init(&list);
+
+    Entity req = make_entity("REQ-001", "Login", ENTITY_KIND_REQUIREMENT);
+    entity_list_add(&list, &req);
+
+    TripletStore *store = build_entity_relation_store(&list);
+    ASSERT_NE(store, nullptr);
+
+    EntityList collected;
+    entity_list_init(&collected);
+
+    EXPECT_EQ(collect_document_entities(&list, store, "SRS-001", &collected), -1);
+    EXPECT_EQ(collected.count, 0);
+
+    entity_list_free(&collected);
+    triplet_store_destroy(store);
+    entity_list_free(&list);
+}
+
+TEST(CollectDocumentEntitiesTest, NonDocumentEntityReturnsMinusTwo)
+{
+    EntityList list;
+    entity_list_init(&list);
+
+    Entity req = make_entity("REQ-001", "Login", ENTITY_KIND_REQUIREMENT);
+    entity_list_add(&list, &req);
+
+    TripletStore *store = build_entity_relation_store(&list);
+    ASSERT_NE(store, nullptr);
+
+    EntityList collected;
+    entity_list_init(&collected);
+
+    EXPECT_EQ(collect_document_entities(&list, store, "REQ-001", &collected), -2);
+    EXPECT_EQ(collected.count, 0);
+
+    entity_list_free(&collected);
+    triplet_store_destroy(store);
+    entity_list_free(&list);
+}
+
+TEST(CollectDocumentEntitiesTest, CollectsDocumentAndMembers)
+{
+    EntityList list;
+    entity_list_init(&list);
+
+    Entity doc = make_entity("SRS-001", "System Requirements", ENTITY_KIND_DOCUMENT);
+    Entity req = make_entity("REQ-001", "Login", ENTITY_KIND_REQUIREMENT);
+    Entity tc  = make_entity("TC-001", "Verify login", ENTITY_KIND_TEST_CASE);
+    Entity ext = make_entity("EXT-001", "IEC 61508", ENTITY_KIND_EXTERNAL);
+
+    strncpy(req.doc_membership.doc_ids, "SRS-001",
+            sizeof(req.doc_membership.doc_ids) - 1);
+    req.doc_membership.count = 1;
+
+    strncpy(tc.traceability.entries, "SRS-001\tpart-of\n",
+            sizeof(tc.traceability.entries) - 1);
+    tc.traceability.count = 1;
+
+    entity_list_add(&list, &doc);
+    entity_list_add(&list, &req);
+    entity_list_add(&list, &tc);
+    entity_list_add(&list, &ext);
+
+    TripletStore *store = build_entity_relation_store(&list);
+    ASSERT_NE(store, nullptr);
+
+    EntityList collected;
+    entity_list_init(&collected);
+
+    ASSERT_EQ(collect_document_entities(&list, store, "SRS-001", &collected), 0);
+    ASSERT_EQ(collected.count, 3);
+    EXPECT_STREQ(collected.items[0].identity.id, "SRS-001");
+    EXPECT_STREQ(collected.items[1].identity.id, "REQ-001");
+    EXPECT_STREQ(collected.items[2].identity.id, "TC-001");
+
+    entity_list_free(&collected);
+    triplet_store_destroy(store);
+    entity_list_free(&list);
+}
+
+/* =========================================================================
  * Tests — list_entities
  * ======================================================================= */
 


### PR DESCRIPTION
## Summary
- add a ibe-req doc <doc-id> subcommand that renders one document plus its member entities via the existing report pipeline
- collect document members from the relation graph so both documents: membership and explicit part-of / contains links are included
- add CLI parsing coverage, document-collection tests, and README / CLI reference updates

## Testing
- git diff --check
- gcc -std=c11 -Wall -Wextra -Wpedantic -O2 -I. -fsyntax-only cli_args.c
- gcc -std=c11 -Wall -Wextra -Wpedantic -O2 -I. -fsyntax-only list_cmd.c
- gcc -std=c11 -Wall -Wextra -Wpedantic -O2 -I. -fsyntax-only main.c
- full make is currently blocked in this Windows/MSYS environment because config.c cannot find yaml.h

Closes #126